### PR TITLE
Fixed memory leak in BMProperty.mm

### DIFF
--- a/BloodMagic/Sources/Modules/Core/Public/Property/BMProperty.mm
+++ b/BloodMagic/Sources/Modules/Core/Public/Property/BMProperty.mm
@@ -189,6 +189,7 @@
         objc_property_attribute_t attribute = attributes[attributeIndex];
         [self parsePropertyAttribute:attribute];
     }
+    free(attributes);
 }
 
 /*


### PR DESCRIPTION
It was forgotten to free the memory allocated by `property_copyAttributeList` in `- (void)parseProperty:(objc_property_t)property`
