### PR TITLE
Improved classes collecting for iOS

### DIFF
--- a/BloodMagic/Sources/Modules/Core/Private/Collectors/BMClassCollector.mm
+++ b/BloodMagic/Sources/Modules/Core/Private/Collectors/BMClassCollector.mm
@@ -40,6 +40,16 @@
 
 - (void)collectClasses
 {
+#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+    uint classesCount;
+    const char *imageName = class_getImageName(object_getClass(self));
+    const char **classNames = objc_copyClassNamesForImage(imageName, &classesCount);
+    for (uint index = 0; index < classesCount; index++) {
+        Class nextClass = objc_getClass(classNames[index]);
+        _cachedClasses.push_back(nextClass);
+    }
+    free(classNames);
+#else
     Class parentClass = [NSObject class];
     int numClasses = objc_getClassList(NULL, 0);
     Class classes[sizeof(Class) * numClasses];
@@ -49,18 +59,19 @@
         do {
             superClass = class_getSuperclass(superClass);
         } while (superClass && superClass != parentClass);
-        
+
         if (superClass == nil) {
             continue;
         }
-        
+
         Class klass = classes[i];
-        
+
         if (class_getName(klass)[0] == '_') {
             continue;
         }
         _cachedClasses.push_back(klass);
     }
+#endif
 }
 
 - (class_list_t *)collectForProtocol:(Protocol *)protocol


### PR DESCRIPTION
As iOS doesn't allow dynamic linking – we can examine only those classes which are in our library's image which is the same image as the rest of user's code.
