### PR TITLE
Skip undefined protocol silently.

### DIFF
--- a/BloodMagic/Sources/Modules/Core/Private/Parsers/BMPropertyTypeParser.mm
+++ b/BloodMagic/Sources/Modules/Core/Private/Parsers/BMPropertyTypeParser.mm
@@ -31,7 +31,7 @@ void BMPropertyTypeParser::parse(const char *type)
             Protocol *protocol = objc_getProtocol(protocolName.c_str());
             
             if (!protocol) {
-                // undefined protocol
+                NSLog(@"BloodMagic: Protocol %s hasn't been found. Please check if you include the header with that protocol description in your .m file", protocolName.c_str());
                 continue;
             }
             


### PR DESCRIPTION
This can happen when you defines the protocol but does not exist class that implement it.
