### PR TITLE
Add refactoring resistant injected hook

### DIFF
--- a/BloodMagic/Sources/Modules/Injectable/Private/BMInjectableHook.mm
+++ b/BloodMagic/Sources/Modules/Injectable/Private/BMInjectableHook.mm
@@ -32,6 +32,10 @@
             [sender performSelector:injectedHook withObject:*value];
 #pragma clang diagnostic pop
         }
+        
+        if ([sender respondsToSelector:@selector(bm_propertyInjected:value:)]) {
+            [sender bm_propertyInjected:property.name value:*value];
+        }
     }
     
     setValueForProperty(sender, property, *value);

--- a/BloodMagic/Sources/Modules/Injectable/Public/BMInjectable.h
+++ b/BloodMagic/Sources/Modules/Injectable/Public/BMInjectable.h
@@ -8,4 +8,7 @@
 @protocol BMInjectable
     <NSObject>
 
+@optional
+- (void)bm_propertyInjected:(NSString *)propertyName value:(id)value;
+
 @end


### PR DESCRIPTION
`- %propertyName%Injected` is stylish, but not refactoring resistant decision. I've added second method, which can help to find broken logic after renaming injected property if user checks property name by `NSStringFromSelector()`.
